### PR TITLE
Add initial configuration for ESLint (fix Codacy issues)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "globals": {
+    "PF": "readonly"
+  }
+}


### PR DESCRIPTION
Codacy uses ESLint. Tell it that certain variables like `PF` are defined. This avoids related issue reports about undefined variables.